### PR TITLE
Adjust alpha_formula to fit initial condiction

### DIFF
--- a/template/alpha_formula.py
+++ b/template/alpha_formula.py
@@ -13,22 +13,22 @@ class AlphaFormula(BaseAlphaFormula):
     DO NOT overload the following methods, or simulation may fail in prod:
             __call__, get_last_success_date
     """
-    def __init__(self, _date, data, parameters):
+    def __init__(self, _startdate, data, parameters):
         """
         Set up the alpha before generating any portfolios.
         If the alpha needs to warm-up before returning its first portfolio.
         """
-        BaseAlphaFormula.__init__(self, _date, data, parameters)
+        BaseAlphaFormula.__init__(self, _startdate, data, parameters)
         self.k_days = parameters['k']
         self.mid_last_k_days = {
-                instrument: deque(
-                        (datum.buy + datum.sell) / 2
-                        for datum in price_data[-self.k_days:])
-                for instrument, price_data in data['currency_price_tw'].items()
+            instrument: deque(
+                (datum.buy + datum.sell) / 2
+                for datum in price_data[-self.k_days - 1: -1])
+            for instrument, price_data in data['currency_price_tw'].items()
         }
         self.sum_last_k_days = {
-                instrument: sum(self.mid_last_k_days[instrument])
-                for instrument in data['currency_price_tw']
+            instrument: sum(self.mid_last_k_days[instrument])
+            for instrument in data['currency_price_tw']
         }
 
     def generate(self, date, data):
@@ -45,5 +45,5 @@ class AlphaFormula(BaseAlphaFormula):
             self.mid_last_k_days[instrument].append(new)
             self.sum_last_k_days[instrument] += new - old
             portfolio[instrument] = (
-                    self.sum_last_k_days[instrument] / self.k_days - new)
+                self.sum_last_k_days[instrument] / self.k_days - new)
         return portfolio


### PR DESCRIPTION
Due to the initialized time is the 'start_date' in alpha_setting, the
data we get is before start_date.
Thus, we should use the previous data before start_date to __init__,
preventing from calculating two times.